### PR TITLE
Added OS checking to scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
+
+# Determnine OS type for venv directories
+binDir="bin" # Default for linux / macos
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
+    binDir="Scripts"
+fi
+
 python -m venv --system-site-packages .venv
 
-.venv/bin/pip3 install --user ./GoVizzy/cube
-.venv/bin/pip3 install --ignore-installed jupyter ipython_genutils ipyvolume pytest ase ipywidgets
+.venv/$binDir/pip3 install --user ./GoVizzy/cube
+.venv/$binDir/pip3 install --ignore-installed jupyter ipython_genutils ipyvolume pytest ase ipywidgets
 
 if [ "$ACTIONS_ENVIRONMENT" = true ]; then
     echo "Running in Github action. Will not start JupyterLab."
     exit 0
 fi
 
-.venv/bin/jupyter lab --notebook-dir=GoVizzy
+.venv/$binDir/jupyter lab --notebook-dir=GoVizzy

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
+# Determnine OS type for venv directories
+binDir="bin" # Default for linux / macos
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
+    binDir="Scripts"
+fi
+
 if [ ! -d .venv ]; then
     echo "No .venv found! Did you forget to run build.sh?"
     exit 1
 fi
 
-.venv/bin/python -m pytest
+.venv/$binDir/python -m pytest


### PR DESCRIPTION
Fixes #82 

## Discussion

Added OS checking to build and test scripts for different .venv directories for Windows. 

## Changes

Modified `build.sh` and `test.sh` with support for .venv `/Scripts/` folder. 

## Testing

- [ ] Run `build.sh` and make sure new dependencies install in .venv
- [ ] Open up the notebook (make sure using the .venv Python kernel)
- [ ] Run `test.sh` and make sure the test passes. 