### PR TITLE
97 fix broken ci icons in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # GoVizzy
 
-[![CI](https://github.com/cs481-ekh/s24-slice-n-dice/actions/workflows/ci.yml/badge.svg?branch=61-create-github-actions-for-test-script&event=pull_request)](https://github.com/cs481-ekh/s24-slice-n-dice/actions/workflows/ci.yml)
-[![CI](https://github.com/cs481-ekh/s24-slice-n-dice/actions/workflows/ci.yml/badge.svg?branch=61-create-github-actions-for-test-script&event=status)](https://github.com/cs481-ekh/s24-slice-n-dice/actions/workflows/ci.yml)
+![Build and Test](https://github.com/cs481-ekh/s24-slice-n-dice/actions/workflows/ci.yml/badge.svg?branch=main)
 
-## Intro
-TDB
 ## Usage
 GoVizzy will work on any system with a supported version on Python and Pip installed.
 
 Simply run the build.sh script, which will install all dependencies in a virtual environment, and launch GoVizzy.
+
+## Documentation
+All of the documentation for GoVizzy can be found in the docs directory. See the [intro page](docs/intro.md).
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GoVizzy
 
-![Build and Test](https://github.com/cs481-ekh/s24-slice-n-dice/actions/workflows/ci.yml/badge.svg?branch=main)
+![CI](https://github.com/cs481-ekh/s24-slice-n-dice/actions/workflows/ci.yml/badge.svg?branch=main)
 
 ## Usage
 GoVizzy will work on any system with a supported version on Python and Pip installed.


### PR DESCRIPTION
Closes #97 

This PR fixes the CI passing icon in the readme. It also adds a link to the documentation.

This has been tested by loading the branch's README in Github and verifying that the CI icon is displaying properly.