### PR TITLE
100 display color picker widget

### DIFF
--- a/GoVizzy/GoVizzy.ipynb
+++ b/GoVizzy/GoVizzy.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from widgets import form\n",
+    "from widgets import form, color\n",
     "import ipyvolume as ipv\n",
     "import numpy as np\n",
     "import cube_viskit as cv"
@@ -21,6 +21,16 @@
    "outputs": [],
    "source": [
     "form"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0672aec9-7539-4165-8997-c2ba20f2652e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "color.value"
    ]
   },
   {

--- a/GoVizzy/GoVizzy.ipynb
+++ b/GoVizzy/GoVizzy.ipynb
@@ -10,9 +10,7 @@
     "from widgets import form\n",
     "import ipyvolume as ipv\n",
     "import numpy as np\n",
-
-    "import cube_viskit as cv\n"
-
+    "import cube_viskit as cv"
    ]
   },
   {
@@ -22,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n"
+    "form"
    ]
   },
   {
@@ -61,7 +59,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/GoVizzy/widgets.py
+++ b/GoVizzy/widgets.py
@@ -12,12 +12,14 @@ form_item_layout = Layout(
     justify_content='space-between'
 )
 
+color = ColorPicker(concise=True, value='blue', description='Color', disabled=False, layout=Layout(flex='1 1 0%', width='auto'))
+
 # Input form items
 form_items = [
 
     Box([Label(value='Path to .cube file'), 
          Textarea()], layout=form_item_layout),
-    ColorPicker(concise=True, value='blue', description='Color', disabled=False, layout=Layout(flex='1 1 0%', width='auto')),
+    color,
     Button(description='Submit', layout=Layout(flex='1 1 0%', width='auto')),
 
 ]
@@ -30,4 +32,4 @@ form = Box(form_items, layout=Layout(
     align_items='stretch',
     width='50%'
 ))
-form
+form, color

--- a/GoVizzy/widgets.py
+++ b/GoVizzy/widgets.py
@@ -3,7 +3,7 @@
     Documentation for widget library: https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20List.html#file-upload
 '''
 from IPython.display import display
-from ipywidgets import Layout, Button, Box, Textarea, Label
+from ipywidgets import Layout, Button, Box, Textarea, Label, ColorPicker
 
 # Layout for Input form
 form_item_layout = Layout(
@@ -17,8 +17,9 @@ form_items = [
 
     Box([Label(value='Path to .cube file'), 
          Textarea()], layout=form_item_layout),
+    ColorPicker(concise=True, value='blue', description='Color', disabled=False, layout=Layout(flex='1 1 0%', width='auto')),
     Button(description='Submit', layout=Layout(flex='1 1 0%', width='auto')),
-    
+
 ]
 
 # Create the input form box


### PR DESCRIPTION
Closes #100 

# Overview
This PR adds a color picker element to the existing form UI element. Users can select a color from a grid of common options or define their own on a color chart. A line of example code is included, showing how to access the selected value.

This PR simply creates the elements as a proof of concept. It is fully expected that they will be removed and relocated in the future, see #101.

# Testing
I manually tested this PR by running the Notebook, selecting different colors, and ensuring the correct hex codes are returned.