### PR TITLE
Implement slider

### DIFF
--- a/GoVizzy/GoVizzy.ipynb
+++ b/GoVizzy/GoVizzy.ipynb
@@ -2,44 +2,70 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "09026008-ce47-49d7-9fca-4b7c123022d1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9d53345258204f8390182d4eedae4194",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Box(children=(Box(children=(Label(value='Path to .cube file'), Textarea(value='')), layout=Layout(display='fle…"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "from widgets import form\n",
+    "from widgets import form, test_slider\n",
     "import ipyvolume as ipv\n",
     "import numpy as np\n",
-
-    "import cube_viskit as cv\n"
-
+    "\n",
+    "form"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "49014e5a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "67faad66-2beb-4746-b0a4-21689ddc78d3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Runs file input until given .cube\n",
-    "%run fileInput.py"
+    "# When testing, we can manually set slider values in code\n",
+    "test_slider.value = 5.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "902364a9-346d-479b-a534-f6f1d3e2727d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5.5"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_slider.value"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "902364a9-346d-479b-a534-f6f1d3e2727d",
+   "id": "3f68260e-7da3-4252-a9cd-91dc1ebdb301",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -61,7 +87,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/GoVizzy/GoVizzy.ipynb
+++ b/GoVizzy/GoVizzy.ipynb
@@ -2,37 +2,22 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "09026008-ce47-49d7-9fca-4b7c123022d1",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9d53345258204f8390182d4eedae4194",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Box(children=(Box(children=(Label(value='Path to .cube file'), Textarea(value='')), layout=Layout(display='fle…"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from widgets import form, test_slider\n",
     "import ipyvolume as ipv\n",
     "import numpy as np\n",
+    "import cube_viskit as cv\n",
     "\n",
     "form"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "67faad66-2beb-4746-b0a4-21689ddc78d3",
    "metadata": {},
    "outputs": [],
@@ -43,21 +28,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "902364a9-346d-479b-a534-f6f1d3e2727d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "5.5"
-      ]
-     },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "test_slider.value"
    ]

--- a/GoVizzy/widgets.py
+++ b/GoVizzy/widgets.py
@@ -1,15 +1,27 @@
 '''This File is for widgets used by GoVizzy
     Input form: widget for uploading a .cube file
+    Options: Widget containing options for customization of output.
     Documentation for widget library: https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20List.html#file-upload
 '''
 from IPython.display import display
-from ipywidgets import Layout, Button, Box, Textarea, Label
+from ipywidgets import Layout, Button, Box, Textarea, Label, FloatSlider
 
+# Input form
 # Layout for Input form
 form_item_layout = Layout(
     display='flex',
     flex_flow='row',
     justify_content='space-between'
+)
+
+test_slider = FloatSlider(
+    value=0,
+    min=0,
+    max=10,
+    step=0.1,
+    description='Example slider!',
+    readout=True,
+    readout_format='.1f'
 )
 
 # Input form items
@@ -18,6 +30,7 @@ form_items = [
     Box([Label(value='Path to .cube file'), 
          Textarea()], layout=form_item_layout),
     Button(description='Submit', layout=Layout(flex='1 1 0%', width='auto')),
+    test_slider,
     
 ]
 
@@ -29,4 +42,4 @@ form = Box(form_items, layout=Layout(
     align_items='stretch',
     width='50%'
 ))
-form
+form, test_slider


### PR DESCRIPTION
Closes #104 

## Discussion

Created a new slider widget, and imported it into the notebook. The value can be read from and manually reassigned in code, which might make testing easier in the future. As far as testing the widgets themselves, Ipywidgets uses the [Galeta](https://github.com/jupyterlab/jupyterlab/tree/main/galata) framework for creating high level unit tests, but this is likely unnecessary, since we will not be creating our own custom widgets, just using and combining existing ones. 

## Testing

- [ ] Run `build.sh` and make sure new dependencies install in .venv
- [ ] Open up the notebook (make sure using the .venv Python kernel)
- [ ] Execute the cells, ensure slider value updates accordingly, and can be read / reset.