### PR TITLE
#98 move to req file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ fi
 python -m venv --system-site-packages .venv
 
 .venv/$binDir/pip3 install --user ./GoVizzy/cube
-.venv/$binDir/pip3 install --ignore-installed jupyter jupyterlab_widgets ipython_genutils ipyvolume pytest ase ipywidgets
+.venv/$binDir/pip3 install --ignore-installed -r requirements.txt
 
 if [ "$ACTIONS_ENVIRONMENT" = true ]; then
     echo "Running in Github action. Will not start JupyterLab."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+ase==3.22.1
+ipython_genutils==0.2.0
+ipywidgets==8.1.2
+ipyvolume==0.6.3
+jupyter==1.0.0
+jupyterlab_widgets==3.0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ipywidgets==8.1.2
 ipyvolume==0.6.3
 jupyter==1.0.0
 jupyterlab_widgets==3.0.10
+pytest==8.1.0


### PR DESCRIPTION
Closes #98 

Moves from hardcoded dependencies in build.sh to a proper requirements.txt file.

PLEASE test this on your own system/setup to ensure that it works for you before it gets merged.