### PR TITLE
#99 added about header

### DIFF
--- a/GoVizzy/GoVizzy.ipynb
+++ b/GoVizzy/GoVizzy.ipynb
@@ -1,6 +1,28 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "5c37196d-992b-419b-b816-16b946be36c2",
+   "metadata": {},
+   "source": [
+    "<details>\n",
+    "<summary>About GoVizzy</summary>\n",
+    "\n",
+    "GoVizzy provides 3D visualizations of atoms and molecules from .cube files.\n",
+    "\n",
+    "You can find documentation for GoVizzy in the docs/ folder.\n",
+    "\n",
+    "GoVizzy was developed as a Computer Science Senior Design Project (SDP) at Boise State University.\n",
+    "\n",
+    "Authors:\n",
+    " - Brayden Thompson\n",
+    " - Digno Teogalbo\n",
+    " - Matthew Oberg\n",
+    " - Rylie Walsh\n",
+    "</details>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "09026008-ce47-49d7-9fca-4b7c123022d1",
@@ -146,7 +168,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Closes #99 

Added an about header explaining what GoVizzy is, explaining where docs can be found, and listing SDP and the authors.