### PR TITLE
#121 don't reinstall if venv exists

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,14 +6,30 @@ if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
     binDir="Scripts"
 fi
 
-python -m venv --system-site-packages .venv
+install()
+{
+    python -m venv --system-site-packages .venv
 
-.venv/$binDir/pip3 install --user ./GoVizzy/cube
-.venv/$binDir/pip3 install --ignore-installed -r requirements.txt
+    .venv/$binDir/pip3 install --user ./GoVizzy/cube
+    .venv/$binDir/pip3 install --ignore-installed -r requirements.txt
+}
 
+launch()
+{
+    .venv/$binDir/jupyter lab --notebook-dir=GoVizzy
+}
+
+if [ -f .venv/$binDir/jupyter ]; then
+    echo "GoVizzy already installed, to reinstall run ./clean.sh then ./build.sh"
+else
+    install
+fi
+
+# Determine if we are in Github Actions
 if [ "$ACTIONS_ENVIRONMENT" = true ]; then
     echo "Running in Github action. Will not start JupyterLab."
     exit 0
 fi
 
-.venv/$binDir/jupyter lab --notebook-dir=GoVizzy
+echo "Launching GoVizzy"
+launch


### PR DESCRIPTION
Closes #121 

build.sh will only run the installation step if Jupyter is not detected in the virtual environment. If GoVizzy is already installed, build.sh only launches the notebook.

Tested this manually, both with and without the virtual environment existing. Verified functionality.