### PR TITLE
Integrated interactive sliders into UI 

### DIFF
--- a/GoVizzy/GoVizzy.ipynb
+++ b/GoVizzy/GoVizzy.ipynb
@@ -24,25 +24,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 16,
    "id": "09026008-ce47-49d7-9fca-4b7c123022d1",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fe1d0a81c0c74a07be2994082d69065b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "AppLayout(children=(HBox(children=(Button(button_style='danger', description='[X]', layout=Layout(margin='0 0 …"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from widgets import form, test_slider\n",
     "from GoVizzy import plotting\n",
@@ -50,7 +35,8 @@
     "import fileInput\n",
     "import ipyvolume as ipv\n",
     "import numpy as np\n",
-    "from cube_viskit import Cube"
+    "from cube_viskit import Cube\n",
+    "import ipywidgets as widgets"
    ]
   },
   {
@@ -81,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "ef52d91c-9d81-41db-953b-78f7ef718f24",
    "metadata": {},
    "outputs": [
@@ -96,7 +82,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "db7b576af62c48a294254ecdc19f7c3b",
+       "model_id": "332c0a197b5d4d3888e7090dae38672a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -112,21 +98,19 @@
     "# Load Cube File\n",
     "cube: Cube = Cube()\n",
     "cube.load_cube(\"data/rhopol.cube\")\n",
-    "visualizer = plotting.Visualizer(cube)\n",
-    "# Display Cube File\n",
-    "visualizer.display_cell()"
+    "visualizer = plotting.Visualizer(cube)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "863d988e-36c3-463b-9b3f-d68e27ceb757",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b7c37980c359447188ef4fb14cece17b",
+       "model_id": "f94b60c35db048e3aea8cc7d730b7a4e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -134,7 +118,7 @@
        "Box(children=(Box(children=(Label(value='Path to .cube file'), Textarea(value='')), layout=Layout(display='fle…"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -145,8 +129,75 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "2cc4ec86-2666-442f-a30b-7727d2a2ad9a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "998610913a6b47e88ecbf88095cf5755",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Container(children=[VBox(children=(HBox(children=(Label(value='levels:'), FloatSlider(value=0.03, max=1.0, ste…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ipv.figure()\n",
+    "transfer = ipv.pylab.transfer_function(level=[0.03, 0.5, 0.47], opacity=[0.05, 0.09, 0.1], level_width=0.1, controls=True)\n",
+    "ipv.pylab.volshow(cube.data3D, ambient_coefficient=0.8, lighting=True, tf=transfer, controls=True)\n",
+    "ipv.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "b86c3388-77b9-42f4-abf6-af22aaa3caee",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c5b04426361541189f0121f718607226",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Container(children=[VBox(children=(HBox(children=(Label(value='levels:'), FloatSlider(value=0.03, max=1.0, ste…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = ipv.figure()\n",
+    "transfer = ipv.pylab.transfer_function(level=[0.03, 0.5, 0.47], opacity=[0.05, 0.09, 0.1], level_width=0.1, controls=True)\n",
+    "#ipv.style.background_color(color.value)\n",
+    "volume = ipv.pylab.volshow(cube.data3D, ambient_coefficient=0.8, lighting=True, tf=transfer, controls=True)\n",
+    "\n",
+    "slice_x = ipv.plot_plane('x', volume=volume, description=\"Slice X\", description_color=\"black\", icon=\"mdi-knife\")\n",
+    "slice_y = ipv.plot_plane('y', volume=volume, description=\"Slice Y\", description_color=\"black\", icon=\"mdi-knife\")\n",
+    "slice_z = ipv.plot_plane('z', volume=volume, description=\"Slice Z\", description_color=\"black\", icon=\"mdi-knife\",\n",
+    "                         visible=False)\n",
+    "\n",
+    "widgets.jslink((fig, 'slice_x'), (slice_x, 'x_offset'))\n",
+    "widgets.jslink((fig, 'slice_y'), (slice_y, 'y_offset'))\n",
+    "widgets.jslink((fig, 'slice_z'), (slice_z, 'z_offset'));\n",
+    "\n",
+    "ipv.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11d761d0-c1ff-4826-a707-6db4ef7b526d",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -168,7 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,

--- a/GoVizzy/GoVizzy.ipynb
+++ b/GoVizzy/GoVizzy.ipynb
@@ -24,14 +24,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "09026008-ce47-49d7-9fca-4b7c123022d1",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "869f8435fb9f401f868f16f2dbec874b",
+       "model_id": "ad9a6950401d4d4e86c575d09ba767fb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -44,7 +44,7 @@
     }
    ],
    "source": [
-    "from widgets import form, test_slider\n",
+    "from widgets import form\n",
     "from GoVizzy import plotting\n",
     "from UI import DisplayUI\n",
     "import fileInput\n",
@@ -56,14 +56,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "id": "67faad66-2beb-4746-b0a4-21689ddc78d3",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e4b35176cd3c4be5bd4d2cb94b0437f8",
+       "model_id": "a1fa4b2a08a348b8a994ceae8119c968",
        "version_major": 2,
        "version_minor": 0
       },
@@ -82,41 +82,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "ef52d91c-9d81-41db-953b-78f7ef718f24",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading data/rhopol.cube ...\n",
-      "Done.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/mnt/c/Users/bt404/Desktop/BSU/s24-slice-n-dice/.venv/lib/python3.12/site-packages/ipyvolume/serialize.py:102: RuntimeWarning: invalid value encountered in cast\n",
-      "  subdata[..., i] = ((gradient[i][zindex] / 2.0 + 0.5) * 255).astype(np.uint8)\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c3ab3bfeb5294d4ebc89673c27ae5ced",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Container(children=[VBox(children=(HBox(children=(Label(value='levels:'), FloatSlider(value=0.03, max=1.0, ste…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Load Cube File\n",
     "cube: Cube = Cube()\n",
@@ -127,26 +96,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "863d988e-36c3-463b-9b3f-d68e27ceb757",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f94b60c35db048e3aea8cc7d730b7a4e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Box(children=(Box(children=(Label(value='Path to .cube file'), Textarea(value='')), layout=Layout(display='fle…"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "form"
    ]

--- a/GoVizzy/GoVizzy.ipynb
+++ b/GoVizzy/GoVizzy.ipynb
@@ -24,35 +24,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "09026008-ce47-49d7-9fca-4b7c123022d1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/mnt/d/Documents/GoVizzy/s24-slice-n-dice/.venv/lib/python3.11/site-packages/pandas/core/arrays/masked.py:60: UserWarning: Pandas requires version '1.3.6' or newer of 'bottleneck' (version '1.3.5' currently installed).\n",
-      "  from pandas.core import (\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9c1c4da74c5e45ebbd1e0cf73c8c6f87",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "AppLayout(children=(HBox(children=(Button(button_style='danger', description='[X]', layout=Layout(margin='0 0 …"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from widgets import form, test_slider\n",
+    "from widgets import form\n",
     "from GoVizzy import plotting, meshes\n",
     "from UI import DisplayUI\n",
     "import fileInput\n",
@@ -64,74 +41,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "67faad66-2beb-4746-b0a4-21689ddc78d3",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0e726288d9a94b7490108b39f2bac979",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "AppLayout(children=(HBox(children=(Button(button_style='danger', description='[X]', layout=Layout(margin='0 0 â€¦"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "126f7927239f487f9c864701be943c96",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(Text(value='', description='File Name:'), Button(description='Submit', style=ButtonStyle())), lâ€¦"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "\n",
-    "\n",
     "%run Main.py"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "ef52d91c-9d81-41db-953b-78f7ef718f24",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading data/rhopol.cube ...\n",
-      "Done.\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d55b62f3bc1246d59178a47ba3fe83d0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Container(children=[VBox(children=(HBox(children=(Label(value='levels:'), FloatSlider(value=0.03, max=1.0, ste…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Load Cube File\n",
     "cube: Cube = Cube()\n",
@@ -146,26 +69,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "863d988e-36c3-463b-9b3f-d68e27ceb757",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b7c37980c359447188ef4fb14cece17b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Box(children=(Box(children=(Label(value='Path to .cube file'), Textarea(value='')), layout=Layout(display='fle…"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "form"
    ]
@@ -195,9 +102,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-
    "version": "3.12.2"
-
   }
  },
  "nbformat": 4,

--- a/GoVizzy/GoVizzy.ipynb
+++ b/GoVizzy/GoVizzy.ipynb
@@ -24,10 +24,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 2,
    "id": "09026008-ce47-49d7-9fca-4b7c123022d1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "869f8435fb9f401f868f16f2dbec874b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "AppLayout(children=(HBox(children=(Button(button_style='danger', description='[X]', layout=Layout(margin='0 0 …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from widgets import form, test_slider\n",
     "from GoVizzy import plotting\n",
@@ -67,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "id": "ef52d91c-9d81-41db-953b-78f7ef718f24",
    "metadata": {},
    "outputs": [
@@ -80,9 +95,17 @@
      ]
     },
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/c/Users/bt404/Desktop/BSU/s24-slice-n-dice/.venv/lib/python3.12/site-packages/ipyvolume/serialize.py:102: RuntimeWarning: invalid value encountered in cast\n",
+      "  subdata[..., i] = ((gradient[i][zindex] / 2.0 + 0.5) * 255).astype(np.uint8)\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "332c0a197b5d4d3888e7090dae38672a",
+       "model_id": "c3ab3bfeb5294d4ebc89673c27ae5ced",
        "version_major": 2,
        "version_minor": 0
       },
@@ -98,7 +121,8 @@
     "# Load Cube File\n",
     "cube: Cube = Cube()\n",
     "cube.load_cube(\"data/rhopol.cube\")\n",
-    "visualizer = plotting.Visualizer(cube)"
+    "visualizer = plotting.Visualizer(cube)\n",
+    "visualizer.display_cell_slices()"
    ]
   },
   {
@@ -126,81 +150,6 @@
    "source": [
     "form"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "2cc4ec86-2666-442f-a30b-7727d2a2ad9a",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "998610913a6b47e88ecbf88095cf5755",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Container(children=[VBox(children=(HBox(children=(Label(value='levels:'), FloatSlider(value=0.03, max=1.0, ste…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "ipv.figure()\n",
-    "transfer = ipv.pylab.transfer_function(level=[0.03, 0.5, 0.47], opacity=[0.05, 0.09, 0.1], level_width=0.1, controls=True)\n",
-    "ipv.pylab.volshow(cube.data3D, ambient_coefficient=0.8, lighting=True, tf=transfer, controls=True)\n",
-    "ipv.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "id": "b86c3388-77b9-42f4-abf6-af22aaa3caee",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c5b04426361541189f0121f718607226",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Container(children=[VBox(children=(HBox(children=(Label(value='levels:'), FloatSlider(value=0.03, max=1.0, ste…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "fig = ipv.figure()\n",
-    "transfer = ipv.pylab.transfer_function(level=[0.03, 0.5, 0.47], opacity=[0.05, 0.09, 0.1], level_width=0.1, controls=True)\n",
-    "#ipv.style.background_color(color.value)\n",
-    "volume = ipv.pylab.volshow(cube.data3D, ambient_coefficient=0.8, lighting=True, tf=transfer, controls=True)\n",
-    "\n",
-    "slice_x = ipv.plot_plane('x', volume=volume, description=\"Slice X\", description_color=\"black\", icon=\"mdi-knife\")\n",
-    "slice_y = ipv.plot_plane('y', volume=volume, description=\"Slice Y\", description_color=\"black\", icon=\"mdi-knife\")\n",
-    "slice_z = ipv.plot_plane('z', volume=volume, description=\"Slice Z\", description_color=\"black\", icon=\"mdi-knife\",\n",
-    "                         visible=False)\n",
-    "\n",
-    "widgets.jslink((fig, 'slice_x'), (slice_x, 'x_offset'))\n",
-    "widgets.jslink((fig, 'slice_y'), (slice_y, 'y_offset'))\n",
-    "widgets.jslink((fig, 'slice_z'), (slice_z, 'z_offset'));\n",
-    "\n",
-    "ipv.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "11d761d0-c1ff-4826-a707-6db4ef7b526d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/GoVizzy/GoVizzy/plotting.py
+++ b/GoVizzy/GoVizzy/plotting.py
@@ -1,5 +1,5 @@
 import os
-from widgets import color
+from widgets import color, slice_x_slider, slice_y_slider, slice_z_slider
 from cube_viskit import Cube
 import ipywidgets as widgets
 import ipyvolume as ipv
@@ -116,6 +116,10 @@ class Visualizer:
         slice_x = ipv.plot_plane('x', volume=volume, description="Slice X", description_color="black", icon="mdi-knife", x_offset=70)
         slice_y = ipv.plot_plane('y', volume=volume, description="Slice Y", description_color="black", icon="mdi-knife", y_offset=70)
         slice_z = ipv.plot_plane('z', volume=volume, description="Slice Z", description_color="black", icon="mdi-knife", z_offset=70)
+        
+        widgets.jslink((slice_x_slider, 'value'), (slice_x, 'x_offset'))
+        widgets.jslink((slice_y_slider, 'value'), (slice_y, 'y_offset'))
+        widgets.jslink((slice_z_slider, 'value'), (slice_z, 'z_offset'))
         
         ipv.show()
         

--- a/GoVizzy/GoVizzy/plotting.py
+++ b/GoVizzy/GoVizzy/plotting.py
@@ -117,5 +117,9 @@ class Visualizer:
         slice_y = ipv.plot_plane('y', volume=volume, description="Slice Y", description_color="black", icon="mdi-knife", y_offset=70)
         slice_z = ipv.plot_plane('z', volume=volume, description="Slice Z", description_color="black", icon="mdi-knife", z_offset=70)
         
+        widgets.jslink((slice_x_slider, 'value'), (slice_x, 'x_offset'))
+        widgets.jslink((slice_y_slider, 'value'), (slice_y, 'y_offset'))
+        widgets.jslink((slice_z_slider, 'value'), (slice_z, 'z_offset'))
+        
         ipv.show()
         

--- a/GoVizzy/GoVizzy/plotting.py
+++ b/GoVizzy/GoVizzy/plotting.py
@@ -100,3 +100,22 @@ class Visualizer:
         ipv.style.background_color(color.value)
         ipv.pylab.volshow(cube.data3D, ambient_coefficient=0.8, lighting=True, tf=transfer, controls=True)
         ipv.show()
+        
+    def display_cell_slices(self):
+        """
+        Displays the cube's data3D with the volshow() method,
+        and attach slices with textures set to the volume data. 
+        """
+        cube = self.cube
+        fig = ipv.figure()
+        transfer = ipv.pylab.transfer_function(level=[0.03, 0.5, 0.47], opacity=[0.05, 0.09, 0.1], level_width=0.1, controls=True)
+        ipv.style.background_color(color.value)
+        volume = ipv.pylab.volshow(cube.data3D, ambient_coefficient=0.8, lighting=True, tf=transfer, controls=True)
+        
+        # Create planes, with textures set to the volume info        
+        slice_x = ipv.plot_plane('x', volume=volume, description="Slice X", description_color="black", icon="mdi-knife", x_offset=70)
+        slice_y = ipv.plot_plane('y', volume=volume, description="Slice Y", description_color="black", icon="mdi-knife", y_offset=70)
+        slice_z = ipv.plot_plane('z', volume=volume, description="Slice Z", description_color="black", icon="mdi-knife", z_offset=70)
+        
+        ipv.show()
+        

--- a/GoVizzy/UI/DisplayUI.py
+++ b/GoVizzy/UI/DisplayUI.py
@@ -1,8 +1,9 @@
+from widgets import slice_x_slider, slice_y_slider, slice_z_slider
 import ipywidgets as widgets
 from ipywidgets import Dropdown, VBox, HBox, Output, ColorPicker, AppLayout, Layout, Label
 import ipyvolume as ipv
 import matplotlib.pyplot as plt
-import GoVizzy.plotting  
+import GoVizzy.plotting
 
 # Define globals
 selected_option = 'Volumetric'
@@ -97,20 +98,19 @@ def display_ipyvolume_plot(cube):
     with large_box:
         #ipv.show()
         visualizer = GoVizzy.plotting.Visualizer(cube)
-        visualizer.display_cell()
+        visualizer.display_cell_slices()
 
 
 def display_app(large_box, additional_box):
     # Attach the dropdown change handler
-   
-    
+      
     # Create a VBox for dropdown
     dropdown_container = VBox([dropdown])
     # Combine the Output widgets with their descriptions
     slice_box = VBox([slice_picker_descr, slice_picker])
     newCube_box = VBox([newCube_descr, newCube])
     
-    menu_options = VBox([dropdown, slice_box, additional_box, newCube_box])
+    menu_options = VBox([dropdown, slice_box, additional_box, slice_x_slider, slice_y_slider, slice_z_slider, newCube_box])
     display_box = HBox([large_box, menu_options])
     
     exit_button = widgets.Button(description='[X]', button_style='danger')

--- a/GoVizzy/widgets.py
+++ b/GoVizzy/widgets.py
@@ -14,12 +14,32 @@ form_item_layout = Layout(
 )
 
 
-test_slider = FloatSlider(
+slice_x_slider = FloatSlider(
     value=0,
     min=0,
-    max=10,
+    max=120,
     step=0.1,
-    description='Example slider!',
+    description='X slice position',
+    readout=True,
+    readout_format='.1f'
+)
+
+slice_y_slider = FloatSlider(
+    value=0,
+    min=0,
+    max=120,
+    step=0.1,
+    description='Y slice position',
+    readout=True,
+    readout_format='.1f'
+)
+
+slice_z_slider = FloatSlider(
+    value=0,
+    min=0,
+    max=120,
+    step=0.1,
+    description='Z slice position',
     readout=True,
     readout_format='.1f'
 )
@@ -34,7 +54,7 @@ form_items = [
          Textarea()], layout=form_item_layout),
     color,
     Button(description='Submit', layout=Layout(flex='1 1 0%', width='auto')),
-    test_slider,
+    slice_x_slider,
 ]
 
 # Create the input form box
@@ -45,4 +65,5 @@ form = Box(form_items, layout=Layout(
     align_items='stretch',
     width='50%'
 ))
-form, color, test_slider
+
+form, color, slice_x_slider, slice_y_slider, slice_z_slider


### PR DESCRIPTION
Closes #123 

## Discussion

Added three sliders, one for each plane using `widgets.jslink()` in order to control the offsets of each of the slices in the graph. (Note toggling visibility is still broken, and will be looked into next)

## Testing

- [ ] Run `build.sh` and make sure new dependencies install in .venv
- [ ] Open up the notebook (make sure using the .venv Python kernel)
- [ ] Execute the cells, and interact with the three sliders on the right of the UI, making sure each one properly controls the position of the corresponding slice plane. 
![image](https://github.com/cs481-ekh/s24-slice-n-dice/assets/77991576/b87de212-db5e-4165-9223-78837364bdeb)

