### PR TITLE
Atom scale float input option

### DIFF
--- a/GoVizzy/gv_ui/gv_ui/DisplayUI.py
+++ b/GoVizzy/gv_ui/gv_ui/DisplayUI.py
@@ -3,7 +3,7 @@ from ipywidgets import Dropdown, VBox, HBox, Output, ColorPicker, AppLayout, Lay
 import ipyvolume as ipv
 import matplotlib.pyplot as plt
 from gv_ui import plotting, meshes, gvWidgets
-from gv_ui.gvWidgets import mesh_visibility_toggle, atom_color_picker
+from gv_ui.gvWidgets import mesh_visibility_toggle, atom_color_picker, atom_scale_slider
 from IPython.display import display
 
 # Define globals
@@ -57,7 +57,6 @@ def show_ui():
 def display_cube(cube):
     global atom_meshes
     visualizer = plotting.Visualizer(cube)
-    global atom_meshes
     with large_box:  # Capture output within large_box
         # Clear previous content
         large_box.clear_output()
@@ -106,7 +105,8 @@ def display_app():
         atom_controls = []
         for mesh in atom_meshes:
             controls = [mesh_visibility_toggle(mesh, 'Visible'),
-                    atom_color_picker(mesh, 'Color')]
+                    atom_color_picker(mesh, 'Color'),
+                    atom_scale_slider(mesh, 'Scale')]
             atom_controls.append(VBox(children=controls))
         titles = tuple(f'Atom {idx}' for idx in range(len(atom_controls)))
         with selected_view_options:

--- a/GoVizzy/gv_ui/gv_ui/gvWidgets.py
+++ b/GoVizzy/gv_ui/gv_ui/gvWidgets.py
@@ -3,8 +3,9 @@
     Documentation for widget library: https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20List.html#file-upload
 '''
 from IPython.display import display
-from ipywidgets import Layout, Button, Box, Textarea, Label, ColorPicker, FloatSlider, Checkbox, link
+from ipywidgets import Layout, Button, Box, Textarea, Label, ColorPicker, FloatSlider, Checkbox, link, BoundedFloatText
 from ipyvolume.widgets import Mesh
+import numpy as np
 
 # Input form
 # Layout for Input form
@@ -77,6 +78,28 @@ def atom_color_picker(atom: Mesh, description: str="Color"):
     picker = ColorPicker(value=str(atom.color), description=description)
     link((picker, 'value'), (atom, 'color'))
     return picker
+
+def scale_atom_mesh(atom: Mesh, points: tuple[list, list, list], origin: tuple[float, float, float], scale: float):
+    x, y, z = points
+    origin_x, origin_y, origin_z = origin
+    scaled_x = (x - origin_x) * scale + origin_x
+    scaled_y = (y - origin_y) * scale + origin_y
+    scaled_z = (z - origin_z) * scale + origin_z
+    atom.x, atom.y, atom.z = scaled_x, scaled_y, scaled_z
+
+def atom_scale_slider(atom: Mesh, description: str="Scale"):
+    slider = BoundedFloatText(
+        value=1,
+        min=0,
+        max=10,
+        step=0.01,
+        description=description,
+        continuous_update=False
+    )
+    points = (list(atom.x), list(atom.y), list(atom.z))
+    origin = (np.mean(atom.x), np.mean(atom.y), np.mean(atom.z))
+    slider.observe(lambda change: scale_atom_mesh(atom, points, origin, change.new), 'value')
+    return slider
 
 # Input form items
 form_items = [


### PR DESCRIPTION
Fixes #164

## Discussion

Adds float input field into the atoms accordions on the "Mesh Options" dropdown. 
![image](https://github.com/cs481-ekh/s24-slice-n-dice/assets/49927429/a857e4b6-3167-452e-b1df-0b6070bbc202)
The task asks for a slider but in testing a slider is difficult to manipulate due to not being able to see scale values and imprecision of the slider control. I opted to use a float input field.

## Testing

- [ ] Run `./build.sh`
- [ ] Run `GoVizzy.ipynb`
- [ ] Switch to "Mesh Options"
- [ ] Verify toggle visibility still works.
- [ ] Verify color picker still works.
- [ ] Verify scale adjustment works.
![image](https://github.com/cs481-ekh/s24-slice-n-dice/assets/49927429/f14773a3-9a87-488b-a1a1-ae2ecb5a4653)
