### PR TITLE
Added slice plots for all 3 axes

### DIFF
--- a/GoVizzy/GoVizzy.ipynb
+++ b/GoVizzy/GoVizzy.ipynb
@@ -32,7 +32,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "53607c596d444a7e970ddd843418c366",
+       "model_id": "6986d7d6e94f493e85d3f3982008c05c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -46,7 +46,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e07b178719f64af8ba8a442d37d4201e",
+       "model_id": "7bfd1d77cd1f49548b40e693ad103f2e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -64,11 +64,70 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "c75f164c-2d9f-44b9-8875-82d7f34a7d4e",
    "metadata": {
     "scrolled": true
    },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imageio: 'stent.npz' was not found on your computer; downloading it now.\n",
+      "Try 1. Download from https://github.com/imageio/imageio-binaries/raw/master/images/stent.npz (805 kB)\n",
+      "Downloading: 8192/824612 bytes (1.0360448/824612 bytes (43.7%824612/824612 bytes (100.0%)\n",
+      "  Done\n",
+      "File saved as /home/brady/.imageio/images/stent.npz.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"100%\"\n",
+       "            height=\"650\"\n",
+       "            src=\"http://127.0.0.1:8050/\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "            \n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x7f933b4677a0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from dash import Dash, html\n",
+    "import imageio\n",
+    "from dash_slicer import VolumeSlicer\n",
+    "\n",
+    "\n",
+    "app = Dash(__name__, update_title=None)\n",
+    "\n",
+    "vol = imageio.volread(\"imageio:stent.npz\")\n",
+    "slicer = VolumeSlicer(app, vol)\n",
+    "slicer.graph.config[\"scrollZoom\"] = False\n",
+    "\n",
+    "app.layout = html.Div([slicer.graph, slicer.slider, *slicer.stores])\n",
+    "\n",
+    "\n",
+    "if __name__ == \"__main__\":\n",
+    "    app.run(debug=True, dev_tools_props_check=False)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9119ed17-151d-4fc8-8aee-d79f7cd4bbd7",
+   "metadata": {},
    "outputs": [],
    "source": []
   }

--- a/GoVizzy/GoVizzy.ipynb
+++ b/GoVizzy/GoVizzy.ipynb
@@ -35,14 +35,6 @@
     "%matplotlib widget\n",
     "%run Main.py\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "04d9e89a-528c-4cf9-97a0-687f4ff969be",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/GoVizzy/GoVizzy.ipynb
+++ b/GoVizzy/GoVizzy.ipynb
@@ -32,8 +32,8 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib widget\n",
-    "%run Main.py\n"
+    "%run Main.py\n",
+    "%matplotlib widget\n"
    ]
   }
  ],

--- a/GoVizzy/gv_ui/gv_ui/plotting.py
+++ b/GoVizzy/gv_ui/gv_ui/plotting.py
@@ -130,10 +130,15 @@ class Visualizer:
         
         plt.style.use('_mpl-gallery-nogrid')
 
-        fig, ax = plt.subplots()
+        fig, (xSlice, ySlice, zSlice) = plt.subplots(1, 3)
 
-        def update(w = 70):
-            ax.imshow(cube.data3D[w])
+        # Slice order is different to match ipyvolume, which plots the volume in a y-up orientation
+        def update(x = 0, y = 0, z = 0):
+            xSlice.imshow(cube.data3D[:, :, x])
+            ySlice.imshow(cube.data3D[:, y, :])
+            zSlice.imshow(cube.data3D[z, :, :])
             plt.show()
 
-        widgets.interact(update, w=widgets.IntSlider(min=0, max=119, step=1, value=70))
+        widgets.interact(update, x=widgets.IntSlider(min=0, max=119, step=1, value=0), 
+                         y=widgets.IntSlider(min=0, max=119, step=1, value=0), 
+                         z=widgets.IntSlider(min=0, max=119, step=1, value=0))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
+dash==2.16.1
+dash-core-components==2.0.0
+dash-html-components==2.0.0
+dash-table==5.0.0
+dash-slicer==0.3.1
+plotly==5.20.0
+imageio==2.34.0
 ase==3.22.1
 ipython_genutils==0.2.0
 ipywidgets==8.1.2


### PR DESCRIPTION
Closes #178

## Discussion

Added all three ipyvolume slices within a single plot, each with an attached slider to control the selected slice. 

## Testing

- [ ] Run `build.sh` and make sure new dependencies install in .venv
- [ ] Open up the notebook (make sure using the .venv Python kernel)
- [ ] Execute the first cell, and ensure that the all three slices show up beneath the ipyvolume graph, and each of the sliders updates the corresponding graph. 
![image](https://github.com/cs481-ekh/s24-slice-n-dice/assets/77991576/52953f07-207d-49fe-8381-f1354626e498)
