### PR TITLE
Re-exposes threshold levels and opacity controls.

### DIFF
--- a/GoVizzy/.virtual_documents/GoVizzy.ipynb
+++ b/GoVizzy/.virtual_documents/GoVizzy.ipynb
@@ -1,36 +1,8 @@
 
 
 
-from widgets import form, test_slider
-from GoVizzy import plotting, meshes
-from UI import DisplayUI
-import fileInput
-import ipyvolume as ipv
-import scipy
-import numpy as np
-from cube_viskit import Cube
-import itertools
-
-
-
-
 %run Main.py
-
-
-# Load Cube File
-cube: Cube = Cube()
-cube.load_cube("data/rhopol.cube")
-visualizer = plotting.Visualizer(cube)
-# Display Cube File
-visualizer.display_cell()
-origin = (50, 50, 50)
-radius = 10
-meshes.plot_sphere_surface(origin, radius)
-
-
-form
-
-
+%matplotlib widget
 
 
 

--- a/GoVizzy/gv_ui/gv_ui/DisplayUI.py
+++ b/GoVizzy/gv_ui/gv_ui/DisplayUI.py
@@ -28,6 +28,9 @@ save_button = Button(description='Save', layout=Layout(flex= '1',  border='1px s
 # atom mesh globals
 atom_meshes = []
 
+# visualizer global
+visualizer = None
+
 def show_menu():
     """
     Displays logo and hides the app output.
@@ -69,7 +72,7 @@ def display_cube(cube):
     Displays the cube plot based on the value of the dropdown.
     """
 
-    global atom_meshes
+    global atom_meshes, visualizer
     visualizer = plotting.Visualizer(cube)
     with large_box:  # Capture output within large_box
         # Clear previous content
@@ -101,58 +104,61 @@ def display_app():
     """
 
     # Containers for right menu 
-    global atom_meshes
-   
+    global atom_meshes, visualizer
     top_container = HBox([dropdown, in_app_exit])
-    
     bottom_container = HBox([newCube_button, save_button])
    
-    # Combine the Output widgets with their descriptions
-    if selected_option == 'Slice Options':
-        #display slidersss TO DO 
-        with selected_view_options:
-            selected_view_options.clear_output()
-            slice_box = VBox([slice_picker_descr, gvWidgets.slice_x_slider, gvWidgets.slice_x_check, gvWidgets.slice_y_slider, gvWidgets.slice_y_check, gvWidgets.slice_z_slider, gvWidgets.slice_z_check])
+    with selected_view_options:
+        selected_view_options.clear_output()
+        figure_controls = visualizer.figure.volumes[0].tf.control()
+        # Combine the Output widgets with their descriptions
+        if selected_option == 'Slice Options':
+            #display slidersss TO DO 
+            slice_box = VBox([slice_picker_descr,
+                              gvWidgets.slice_x_slider,
+                              gvWidgets.slice_x_check,
+                              gvWidgets.slice_y_slider,
+                              gvWidgets.slice_y_check,
+                              gvWidgets.slice_z_slider,
+                              gvWidgets.slice_z_check,
+                              figure_controls])
             display(slice_box)
-        
-        
-    
-    
-    elif selected_option == 'Mesh Options':
-        #display Mesh TO DO
-        atom_controls = []
-        for mesh in atom_meshes:
-            controls = [mesh_visibility_toggle(mesh, 'Visible'),
-                    atom_color_picker(mesh, 'Color'),
-                    atom_scale_slider(mesh, 'Scale')]
-            atom_controls.append(VBox(children=controls))
-        titles = tuple(f'Atom {idx}' for idx in range(len(atom_controls)))
-        
-        print(atom_controls)
-        print(titles)
-        
-        with selected_view_options:
-            selected_view_options.clear_output()
-            accordion = Accordion(children=atom_controls, titles=titles)
-            mesh_box = VBox([accordion, gvWidgets.bond_visibility_toggle, gvWidgets.bond_color_picker, gvWidgets.bond_scale_slider])
-            display(mesh_box)
+            
             
         
+        
+        elif selected_option == 'Mesh Options':
+            #display Mesh TO DO
+            atom_controls = []
+            for mesh in atom_meshes:
+                controls = [mesh_visibility_toggle(mesh, 'Visible'),
+                        atom_color_picker(mesh, 'Color'),
+                        atom_scale_slider(mesh, 'Scale')]
+                atom_controls.append(VBox(children=controls))
+            titles = tuple(f'Atom {idx}' for idx in range(len(atom_controls)))
+            
+            accordion = Accordion(children=atom_controls, titles=titles)
+            mesh_box = VBox([accordion,
+                             gvWidgets.bond_visibility_toggle,
+                             gvWidgets.bond_color_picker,
+                             gvWidgets.bond_scale_slider,
+                             figure_controls])
+            display(mesh_box)
+                
+            
 
-    
-    
-    elif selected_option == 'Color Options':
-        #ADD color controls here 
-        with selected_view_options:
-            selected_view_options.clear_output()
         
         
-    
-    
-    
-    else:
+        elif selected_option == 'Color Options':
+            #ADD color controls here 
+            pass
+            
+        
+        
+        
+        else:
             print("Invalid option selected")
-    
+
     # Display the layout
     view_bar = VBox([top_container, selected_view_options, bottom_container], layout=Layout(flex='1'))
        

--- a/GoVizzy/gv_ui/gv_ui/plotting.py
+++ b/GoVizzy/gv_ui/gv_ui/plotting.py
@@ -5,6 +5,7 @@ import ipyvolume as ipv
 from IPython.display import display
 from gv_ui import gvWidgets
 import matplotlib.pyplot as plt
+from ipyvolume import Figure
 
 class Visualizer:
     """
@@ -15,6 +16,7 @@ class Visualizer:
     """
 
     cube: Cube
+    figure: Figure
 
     def __init__(self, cube: Cube):
         self.cube = cube
@@ -96,7 +98,7 @@ class Visualizer:
         Displays the cube's data3D with the volshow() method.
         """
         cube = self.cube
-        ipv.figure()
+        self.figure = ipv.figure()
         transfer = ipv.pylab.transfer_function(level=[0.03, 0.5, 0.47], opacity=[0.05, 0.09, 0.1], level_width=0.1, controls=False)
         ipv.style.background_color(gvWidgets.color.value)
         ipv.pylab.volshow(cube.data3D, ambient_coefficient=0.8, lighting=True, tf=transfer, controls=False)
@@ -108,7 +110,7 @@ class Visualizer:
         and attach slices with textures set to the volume data. 
         """
         cube = self.cube
-        fig = ipv.figure()
+        self.figure = ipv.figure()
         transfer = ipv.pylab.transfer_function(level=[0.03, 0.5, 0.47], opacity=[0.05, 0.09, 0.1], level_width=0.1, controls=False)
         ipv.style.background_color(gvWidgets.color.value)
         volume = ipv.pylab.volshow(cube.data3D, ambient_coefficient=0.8, lighting=True, tf=transfer, controls=False)


### PR DESCRIPTION
Fixes #183 

## Discussion

This creates an instance variable within the Visualizer class that re-exposes the original figure's transfer function widget controls. By exposing that transfer function widget controls we can display that within the selected view controls.

## Testing

- [ ] Perform `./clean.sh` and `./build.sh` (No new dependencies have been installed.)
- [ ] Run the `GoVizzy.ipynb`
- [ ] Verify that all selection view controls contains the levels and opacity controls.
- [ ] Verify that changing slider values adjusts the threshold and opacity for the volume within the figure.
![image](https://github.com/cs481-ekh/s24-slice-n-dice/assets/49927429/0172496b-5734-44f7-aab4-2977d4e49b98)
![image](https://github.com/cs481-ekh/s24-slice-n-dice/assets/49927429/3f209173-f0b4-4266-b3b3-f84273c55f08)
