### PR TITLE
Set slider max to match cube file size

### DIFF
--- a/GoVizzy/gv_ui/gv_ui/plotting.py
+++ b/GoVizzy/gv_ui/gv_ui/plotting.py
@@ -112,12 +112,25 @@ class Visualizer:
         transfer = ipv.pylab.transfer_function(level=[0.03, 0.5, 0.47], opacity=[0.05, 0.09, 0.1], level_width=0.1, controls=False)
         ipv.style.background_color(gvWidgets.color.value)
         
-        volume = ipv.pylab.volshow(cube.data3D, ambient_coefficient=0.8, lighting=True, tf=transfer, controls=False)
+        xLen = len(cube.data3D[0][0])
+        yLen = len(cube.data3D[0])
+        zLen = len(cube.data3D)
+        
+        ipv.pylab.xlim(0, xLen)
+        ipv.pylab.ylim(0, yLen)
+        ipv.pylab.zlim(0, zLen)
+        
+        volume = ipv.pylab.volshow(cube.data3D, ambient_coefficient=0.8, lighting=True, tf=transfer, controls=False, extent=[[0, xLen], [0, yLen], [0, zLen]])
         
         # Create planes, with textures set to the volume info        
         slice_x = ipv.plot_plane('x', volume=volume, description="Slice X", description_color="black", icon="mdi-knife", x_offset=70)
         slice_y = ipv.plot_plane('y', volume=volume, description="Slice Y", description_color="black", icon="mdi-knife", y_offset=70)
         slice_z = ipv.plot_plane('z', volume=volume, description="Slice Z", description_color="black", icon="mdi-knife", z_offset=70)
+        
+        #Set slider max to cube
+        gvWidgets.slice_x_slider.max = xLen-1
+        gvWidgets.slice_y_slider.max = yLen-1
+        gvWidgets.slice_z_slider.max = zLen-1
         
         widgets.jslink((gvWidgets.slice_x_slider, 'value'), (slice_x, 'x_offset'))
         widgets.jslink((gvWidgets.slice_y_slider, 'value'), (slice_y, 'y_offset'))


### PR DESCRIPTION
Closes #191 

## Discussion

Set slider values to max of each cube file dimension. Note: Aspect ratio within the ipyvolume still forced into a cube, this would need more complicated controls maintain the correct aspect ratio and be able to control which section is shown. 

## Testing

- [ ] Run `build.sh` and make sure new dependencies install in .venv
- [ ] Open up the notebook (make sure using the .venv Python kernel)
- [ ] Execute the first cell, and **Import a non-rhopol.cube** cube file, making sure that the sliders can go to the max of each dimension (-1 for indexing). `fukui_negative_defect.cube` was used as an example, and has dimensions of 120, 135, 320.
- [ ] Ensure that the 3d slice planes can go all the way to the edge of the graph. 
![image](https://github.com/cs481-ekh/s24-slice-n-dice/assets/77991576/4224dd59-d398-4be5-8763-ad99df1e3bea)

